### PR TITLE
Fix post sorting

### DIFF
--- a/models/post.rb
+++ b/models/post.rb
@@ -137,7 +137,7 @@ class Post
               posts << Post.get( site_id, post_id) unless File.directory? yaml_config
             end
         end
-        return posts
+        return posts.sort {|a,b| b.settings['date'] <=> a.settings['date'] }
     end
 
 end

--- a/models/post.rb
+++ b/models/post.rb
@@ -128,8 +128,10 @@ class Post
         posts_dir = Utterson.settings.sites_dir + site_id + '/_posts'
         posts = Array.new
         Dir.entries( posts_dir ).reverse.each do |post_id|
-            yaml_config = posts_dir + '/' + post_id
-            posts << Post.get( site_id, post_id) unless File.directory? yaml_config
+            unless post_id =~ /~$/
+              yaml_config = posts_dir + '/' + post_id
+              posts << Post.get( site_id, post_id) unless File.directory? yaml_config
+            end
         end
         return posts
     end

--- a/models/post.rb
+++ b/models/post.rb
@@ -29,6 +29,10 @@ class Post
         return false unless File.exists? self.filename
         raw_post = File.read( self.filename )
 
+        # Set date from filename here, it may be overridden if
+        # specified in the YAML front matter too
+        @settings['date'] = DateTime.parse(post_id[0..9]).strftime('%F %T')
+
         YAML::load( raw_post ).each do |name, value|
             case name
             when 'category'


### PR DESCRIPTION
Fixes sorting of posts without a publishing date specified in the front matter yaml. This will often be the case for sites that has been created or edited by a regular editor/command line workflow. This patch set picks up the date from the post file name, as well as skipping backup (*~) files. Also the posts are sorted according to the specified date, not the file system date/time.

If the publishing date is specified in the yaml front-matter that value will override the date picked up from post the filename.
