### PR TITLE
Fix link to deploy documentation

### DIFF
--- a/views/deploy/list.erb
+++ b/views/deploy/list.erb
@@ -6,7 +6,7 @@
 
     <div class="alert alert-danger" role="alert">
         <strong>Error!</strong> No environments exists to deploy to!<br />
-        Read more in <a href="http://gabriel-john.github.io/docs/">the documentation</a> on how to setup environments.
+        Read more in <a href="https://github.com/gabriel-john/utterson#how-to-setup-deploys-of-jekyll-sites-within-utterson">the documentation</a> on how to setup environments.
     </div>
 
 <% else %>


### PR DESCRIPTION
( The website isn't up yet )

Currently, if you visit the deploy page and deploy isn't setup, there is a ( broken ) link to documentation on how to set it up. Change the link to point at the README - which currently is the best source for documentation.
